### PR TITLE
试图修复行内代码<, >转义的问题

### DIFF
--- a/script/framework/mikumark.js
+++ b/script/framework/mikumark.js
@@ -100,7 +100,11 @@ var Mikumark = /** @class */ (function () {
         // 行内代码：需要特殊处理，其内的所有元字符都应被转义，防止解析成HTML标签。（不会处理已屏蔽的元字符）
         var inlineCodeSegments = RegexInlineCode.exec(HTML);
         while (inlineCodeSegments !== null) {
-            HTML = HTML.replace(inlineCodeSegments[0], "<code class=\"MikumarkCode\">" + Mikumark.CoverHTMLchar(Mikumark.CoverMetachar(inlineCodeSegments[1])) + "</code>");
+          var rhs = inlineCodeSegments[1];
+            HTML = HTML.replace(inlineCodeSegments[0],
+              "<code class=\"MikumarkCode\"> <script type=\"text/html\" style=\"display: inline\">"
+              + rhs
+              + "</script></code>");
             inlineCodeSegments = RegexInlineCode.exec(HTML);
         }
         // TODO 处理标签
@@ -112,7 +116,6 @@ var Mikumark = /** @class */ (function () {
             .replace(RegexColor, "<span style=\"color:$1;\">$2</span>")
             .replace(RegexSelfLink, "<a class=\"MikumarkLink\" target=\"_blank\" href=\"$1\">$1</a>")
             .replace(RegexLink, "<a class=\"MikumarkLink\" target=\"_blank\" href=\"$2\">$1</a>");
-        // return Mikumark.RecoverHTMLchar(Mikumark.RecoverMetachar(HTML));
         return Mikumark.RecoverMetachar(HTML);
     };
     // 段落级样式解析
@@ -412,7 +415,7 @@ var Mikumark = /** @class */ (function () {
             if (/^(>*)\s*```/g.test(para) === true) {
                 var index = parseInt(para.trim().replace(/^(>*)\s*```/g, ""));
                 var codeBlock = codeBlocks[index];
-                var code = Mikumark.RecoverHTMLchar(codeBlock.code);
+                var code = Mikumark.RecoverMetachar(Mikumark.RecoverHTMLchar(codeBlock.code));
                 HtmlBuffer[i] = "<pre class=\"MikumarkPre\"><code class=\"MikumarkCode\">" + code + "</code></pre>";
             }
         }


### PR DESCRIPTION
修改了`mikumark.js`部分内容, 通过外套
`<script type="text/html">...</script>`的方式来避免转义错误.

修复后的效果见 [这里](https://zero-cost.xyz/#/blog/%E5%8F%82%E6%95%B0%E5%8C%85%E5%92%8Cfold)
这个链接展示的页面是使用了这个修改之后渲染出来的文章页. 
可以看到, 代码块中的`<,>`和行内的`<>`都可以很好的渲染.